### PR TITLE
Use static get methods instead of static properties

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -5,21 +5,23 @@ class User extends BaseModel {
   static get tableName() {
     return "users";
   }
-  static relationMappings = {
-    vehicles: {
-      relation: Model.HasManyRelation,
-      modelClass: "./Vehicle",
-      join: {
-        from: "users.id",
-        // Any of the `to` and `from` fields can also be
-        // references to nested fields (or arrays of references).
-        // Here the relation is created between `persons.id` and
-        // `animals.json.details.ownerId` properties. The reference
-        // must be cast to the same type as the other key.
-        to: "vehicles.owner_id"
+  static get relationMappings() {
+    return {
+      vehicles: {
+        relation: Model.HasManyRelation,
+        modelClass: "./Vehicle",
+        join: {
+          from: "users.id",
+          // Any of the `to` and `from` fields can also be
+          // references to nested fields (or arrays of references).
+          // Here the relation is created between `persons.id` and
+          // `animals.json.details.ownerId` properties. The reference
+          // must be cast to the same type as the other key.
+          to: "vehicles.owner_id"
+        }
       }
-    }
-  };
+    };
+  }
 }
 
 module.exports = User;

--- a/models/Vehicle.js
+++ b/models/Vehicle.js
@@ -5,21 +5,23 @@ class Vehicle extends BaseModel {
   static get tableName() {
     return "vehicles";
   }
-  static relationMappings = {
-    owner: {
-      relation: Model.BelongsToOneRelation,
-      modelClass: "./User",
-      join: {
-        from: "vehicles.owner_id",
-        // Any of the `to` and `from` fields can also be
-        // references to nested fields (or arrays of references).
-        // Here the relation is created between `persons.id` and
-        // `animals.json.details.ownerId` properties. The reference
-        // must be cast to the same type as the other key.
-        to: "user.id"
+  static get relationMappings() {
+    return {
+      owner: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: "./User",
+        join: {
+          from: "vehicles.owner_id",
+          // Any of the `to` and `from` fields can also be
+          // references to nested fields (or arrays of references).
+          // Here the relation is created between `persons.id` and
+          // `animals.json.details.ownerId` properties. The reference
+          // must be cast to the same type as the other key.
+          to: "user.id"
+        }
       }
-    }
-  };
+    };
+  }
 }
 
 module.exports = Vehicle;


### PR DESCRIPTION
The node start script wasn't running, erroring on `static relationMappings = ...` so I switched these to `static get relationMappings() { ... }` which solved the issue for me.